### PR TITLE
Fix iOS timeout issue

### DIFF
--- a/ModernHttpClient.iOS/NSUrlSessionHandler.cs
+++ b/ModernHttpClient.iOS/NSUrlSessionHandler.cs
@@ -214,7 +214,7 @@ namespace ModernHttpClient
             }
 
             if (Timeout != null)
-                rq.TimeoutInterval = Timeout.Value.Seconds;
+                rq.TimeoutInterval = Timeout.Value.TotalSeconds;
 
             var op = session.CreateDataTask(rq);
 


### PR DESCRIPTION
TotalSeconds property gets the value of the current TimeSpan structure expressed in whole and fractional seconds.