### PR TITLE
fix for #57 on android 5.0 application crashes 

### DIFF
--- a/ModernHttpClient.Android/OkHttpNetworkHandler.cs
+++ b/ModernHttpClient.Android/OkHttpNetworkHandler.cs
@@ -60,7 +60,7 @@ namespace ModernHttpClient
 
             var specs = new List<ConnectionSpec>() { tlsSpec };
 
-            if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop || NetworkSecurityPolicy.Instance.IsCleartextTrafficPermitted)
+            if (Build.VERSION.SdkInt < BuildVersionCodes.M || NetworkSecurityPolicy.Instance.IsCleartextTrafficPermitted)
             {
                 specs.Add(ConnectionSpec.Cleartext);
             }


### PR DESCRIPTION
because `NetworkSecurityPolicy` was introduced in 23 api level