### PR TITLE
Prevent NullReferenceException in OnFailureCallback

### DIFF
--- a/ModernHttpClient.Android/OkHttpNetworkHandler.cs
+++ b/ModernHttpClient.Android/OkHttpNetworkHandler.cs
@@ -373,8 +373,10 @@ namespace ModernHttpClient
 
             public void OnFailure(ICall p0, IOException p1)
             {
+                var host = p0?.Request()?.Url()?.Host();
+
                 // Kind of a hack, but the simplest way to find out that server cert. validation failed
-                if (p1.Message.StartsWith("Hostname " + p0.Request().Url().Host() + " not verified", StringComparison.Ordinal))
+                if (host != null && p1.Message != null && p1.Message.StartsWith("Hostname " + host + " not verified", StringComparison.Ordinal))
                 {
                     // SIGABRT after UnknownHostException #229
                     //tcs.TrySetException(new WebException(p1.Message));
@@ -383,7 +385,7 @@ namespace ModernHttpClient
                     HostnameVerifier.PinningFailureMessage = null;
                     tcs.TrySetException(ex);
                 }
-                else if (p1.Message.StartsWith("Certificate pinning failure", StringComparison.Ordinal))
+                else if (p1.Message != null && p1.Message.StartsWith("Certificate pinning failure", StringComparison.Ordinal))
                 {
                     System.Diagnostics.Debug.WriteLine(p1.Message);
                     tcs.TrySetException(new System.OperationCanceledException(FailureMessages.PinMismatch, p1));


### PR DESCRIPTION
I encountered a crash recently using the library.
From the stacktrace, it's caused by an NRE in the OnFailure method of the OkTaskCallback.

I added null check in two places :
- The hostname retrieval, perhaps not all check needed  but I prefer to be safe
- The exception message, because it's a Java exception here, and in Java unlike C#, exception message can be null

The changes are only in the OnFailure method.
I tried to disable the git normalization line ending but it doesn't seem to work 🤷‍♂.